### PR TITLE
Automatically label PRs based on files changed

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+# Label PRs based on changes to crates (see https://github.com/actions/labeler)
+arrow:
+  any: ['arrow/**/*']
+
+arrow-flight:
+  any: ['arrow-flight/**/*']
+
+development-process:
+  any: ['dev/**/*']
+
+parquet:
+  any: ['parquet/**/*', 'parquet-testing/**/*', 'parquet_derive/**/*','parquet_derive_test/**/*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Label PRs based on changes to crates (see https://github.com/actions/labeler)
 arrow:
   any: ['arrow/**/*']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: "Pull Request Labeler"
 on:
 - pull_request_target


### PR DESCRIPTION
(testing PR against alamb/arrow-rs)

# Rationale:
Locate PRs that affect various parts of the codebase to make it easier to find PRs in need of review

# Changes:
1. Add labeler action, using standard github action (https://github.com/actions/labeler)

# Notes
You can see this working on https://github.com/alamb/arrow-rs (TODO link) 
