### PR TITLE
Require HeapSize for ParquetValueType

### DIFF
--- a/parquet/src/file/metadata/memory.rs
+++ b/parquet/src/file/metadata/memory.rs
@@ -28,7 +28,7 @@ use crate::format::{BoundaryOrder, PageLocation, SortingColumn};
 use std::sync::Arc;
 
 /// Trait for calculating the size of various containers
-pub(crate) trait HeapSize {
+pub trait HeapSize {
     /// Return the size of any bytes allocated on the heap by this object,
     /// including heap memory in those structures
     ///
@@ -176,11 +176,30 @@ impl<T: ParquetValueType> HeapSize for ValueStatistics<T> {
         self.min().heap_size() + self.max().heap_size()
     }
 }
-
-// Note this impl gets most primitive types like bool, i32, etc
-impl<T: ParquetValueType> HeapSize for T {
+impl HeapSize for bool {
     fn heap_size(&self) -> usize {
-        self.heap_size()
+        0 // no heap allocations
+    }
+}
+impl HeapSize for i32 {
+    fn heap_size(&self) -> usize {
+        0 // no heap allocations
+    }
+}
+impl HeapSize for i64 {
+    fn heap_size(&self) -> usize {
+        0 // no heap allocations
+    }
+}
+
+impl HeapSize for f32 {
+    fn heap_size(&self) -> usize {
+        0 // no heap allocations
+    }
+}
+impl HeapSize for f64 {
+    fn heap_size(&self) -> usize {
+        0 // no heap allocations
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

Part of https://github.com/apache/arrow-rs/issues/1729 

# Rationale for this change
 
Targets https://github.com/apache/arrow-rs/pull/5965 showing what the suggestion https://github.com/apache/arrow-rs/pull/5965/files#r1660886136 from @crepereum would look like 

# What changes are included in this PR?

make `ParquetValueType` require `HeapSize` rather than implement `heap_size` as a method

# Are there any user-facing changes?

It would require `HeapSize` to become a public type

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
